### PR TITLE
Remove jackson databind and jackson annotations dependency now coming from core #2325

### DIFF
--- a/.github/workflows/sql-jdbc-test-and-build-workflow.yml
+++ b/.github/workflows/sql-jdbc-test-and-build-workflow.yml
@@ -1,6 +1,7 @@
 name: SQL JDBC Java CI
 
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches-ignore:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<img src="https://opensearch.org/assets/img/opensearch-logo-themed.svg" height="64px">
+
 ## OpenSearch - JDBC
 
 This is the driver for JDBC connectivity to a cluster running with OpenSearch SQL support.

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
 
 
@@ -47,7 +48,6 @@ repositories {
 
 dependencies {
     implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "2.13.3"
     implementation group: 'com.amazonaws', name: 'aws-java-sdk-core', version: '1.11.452'
 
     testImplementation('org.junit.jupiter:junit-jupiter-api:5.3.1')


### PR DESCRIPTION
### Description

jackson-databind and jackson-annotations were added as api dependencies in server of opensearch core. The security plugin now gets these dependencies transitively and does not need direct dependencies on the jars.

PR in core where the dependencies are added: https://github.com/opensearch-project/OpenSearch/pull/5366

_In addition_
 - adding logo in README.md
 - adding 'workflow_dispatch' in github workflow's CI

#### Category
 (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation) Maintenance
 
### Issues Resolved
 https://github.com/opensearch-project/OpenSearch/pull/5366
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).