### PR TITLE
Fixes "`ResultSet.getTime()` returns `null`" bug

### DIFF
--- a/src/main/java/org/opensearch/jdbc/ResultSetImpl.java
+++ b/src/main/java/org/opensearch/jdbc/ResultSetImpl.java
@@ -347,14 +347,18 @@ public class ResultSetImpl implements ResultSet, JdbcWrapper, LoggingSource {
     public Time getTime(int columnIndex) throws SQLException {
         log.debug(() -> logEntry("getTime (%d)", columnIndex));
         checkCursorOperationPossible();
-        Time value = getTimeX(columnIndex);
+        Time value = getTimeX(columnIndex, null);
         log.debug(() -> logExit("getTime", value));
         return value;
     }
 
-    private Time getTimeX(int columnIndex) throws SQLException {
-        // TODO - add/check support
-        return getObjectX(columnIndex, Time.class);
+    private Time getTimeX(int columnIndex, Calendar calendar) throws SQLException {
+        Map<String, Object> conversionParams = null;
+        if (calendar != null) {
+            conversionParams = new HashMap<>();
+            conversionParams.put("calendar", calendar);
+        }
+        return getObjectX(columnIndex, Time.class, conversionParams);
     }
 
     @Override
@@ -494,7 +498,7 @@ public class ResultSetImpl implements ResultSet, JdbcWrapper, LoggingSource {
     public Time getTime(String columnLabel) throws SQLException {
         log.debug(() -> logEntry("getTime (%s)", columnLabel));
         checkCursorOperationPossible();
-        Time value = getTimeX(getColumnIndex(columnLabel));
+        Time value = getTimeX(getColumnIndex(columnLabel), null);
         log.debug(() -> logExit("getTime", value));
         return value;
     }
@@ -1071,14 +1075,22 @@ public class ResultSetImpl implements ResultSet, JdbcWrapper, LoggingSource {
 
     @Override
     public Time getTime(int columnIndex, Calendar cal) throws SQLException {
-        // TODO - implement?
-        return null;
+        log.debug(() -> logEntry("getTime (%d, %s)", columnIndex,
+                cal == null ? "null" : "Calendar TZ= " + cal.getTimeZone()));
+        checkCursorOperationPossible();
+        Time value = getTimeX(columnIndex, cal);
+        log.debug(() -> logExit("getTime", value));
+        return value;
     }
 
     @Override
     public Time getTime(String columnLabel, Calendar cal) throws SQLException {
-        // TODO - implement?
-        return null;
+        log.debug(() -> logEntry("getTime (%s, %s)", columnLabel,
+                cal == null ? "null" : "Calendar TZ= " + cal.getTimeZone()));
+        checkCursorOperationPossible();
+        Time value = getTimeX(getColumnIndex(columnLabel), cal);
+        log.debug(() -> logExit("getTime", value));
+        return value;
     }
 
     @Override

--- a/src/main/java/org/opensearch/jdbc/types/TypeConverters.java
+++ b/src/main/java/org/opensearch/jdbc/types/TypeConverters.java
@@ -66,7 +66,7 @@ public class TypeConverters {
 
         private static final Set<Class> supportedJavaClasses = Collections.unmodifiableSet(
                 new HashSet<>(Arrays.asList(
-                        String.class, Timestamp.class
+                        String.class, Timestamp.class, Time.class
                 )));
 
         private TimestampTypeConverter() {

--- a/src/test/java/org/opensearch/jdbc/types/TimeTypeTest.java
+++ b/src/test/java/org/opensearch/jdbc/types/TimeTypeTest.java
@@ -8,8 +8,13 @@ package org.opensearch.jdbc.types;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
 import org.opensearch.jdbc.test.UTCTimeZoneTestExtension;
 import java.sql.Time;
+import java.time.LocalTime;
+import java.util.Calendar;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -22,11 +27,64 @@ public class TimeTypeTest {
   @CsvSource(value = {
       "00:00:00, 00:00:00",
       "01:01:01, 01:01:01",
-      "23:59:59, 23:59:59"
+      "23:59:59, 23:59:59",
+      "1880-12-22 00:00:00, 00:00:00",
+      "2000-01-10 01:01:01, 01:01:01",
+      "1998-08-17 23:59:59, 23:59:59"
   })
   void testTimeFromString(String inputString, String resultString) {
     Time time = Assertions.assertDoesNotThrow(
         () -> TimeType.INSTANCE.fromValue(inputString, null));
     assertEquals(resultString, time.toString());
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+      "00:00:00, 00:00:00",
+      "01:01:01, 01:01:01",
+      "23:59:59, 23:59:59",
+      "1880-12-22 00:00:00, 00:00:00",
+      "2000-01-10 01:01:01, 01:01:01",
+      "1998-08-17 23:59:59, 23:59:59"
+  })
+  void testTimeFromStringWithCalendar(String inputString, String resultString) {
+    Time time = Assertions.assertDoesNotThrow(
+            () -> TimeType.INSTANCE.fromValue(
+                    inputString, ImmutableMap.of("calendar", Calendar.getInstance())));
+    assertEquals(resultString, time.toString());
+  }
+
+  @Test
+  void testTimeFromTime() {
+    Time timeNow = Time.valueOf(LocalTime.now());
+    Time time = Assertions.assertDoesNotThrow(
+            () -> TimeType.INSTANCE.fromValue(timeNow, null));
+    assertEquals(timeNow, time);
+  }
+
+  @Test
+  void testTimeFromTimeWithCalendar() {
+    Time timeNow = Time.valueOf(LocalTime.now());
+    Time time = Assertions.assertDoesNotThrow(
+            () -> TimeType.INSTANCE.fromValue(
+                    timeNow, ImmutableMap.of("calendar", Calendar.getInstance())));
+    assertEquals(timeNow, time);
+  }
+
+  @Test
+  void testTimeFromNumber() {
+    long currentTimestamp = System.currentTimeMillis();
+    Time time = Assertions.assertDoesNotThrow(
+            () -> TimeType.INSTANCE.fromValue(currentTimestamp, null));
+    assertEquals(currentTimestamp, time.getTime());
+  }
+
+  @Test
+  void testTimeFromNumberWithCalendar() {
+    long currentTimestamp = System.currentTimeMillis();
+    Time time = Assertions.assertDoesNotThrow(
+            () -> TimeType.INSTANCE.fromValue(
+                    currentTimestamp, ImmutableMap.of("calendar", Calendar.getInstance())));
+    assertEquals(currentTimestamp, time.getTime());
   }
 }


### PR DESCRIPTION
Signed-off-by: Margarit Hakobyan <margarit.hakobyan@improving.com>

### Description
`ResultSet.getTime()` returns non-null value reflecting the retrieved time instead of `null`.
 
### Issues Resolved
https://github.com/opensearch-project/sql-jdbc/issues/20
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).