### PR TITLE
Update `wiremock` and `jetty`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ plugins {
     id 'signing'
 }
 
-group 'org.opensearch.client'
+group 'org.opensearch.driver'
 
 // keep version in sync with version in Driver source
 version '2.0.0.0'
@@ -89,7 +89,7 @@ tasks.withType(JavaCompile) {
 }
 
 static def getShadowPath(String path) {
-    return 'com.amazonaws.opensearch.sql.jdbc.shadow.' + path
+    return 'org.opensearch.sql.jdbc.shadow.' + path
 }
 
 shadowJar {
@@ -107,10 +107,7 @@ shadowJar {
     exclude 'META-INF/NOTICE*'
     exclude 'META-INF/DEPENDENCIES'
 
-    relocate('com.amazonaws', getShadowPath('com.amazonaws')) {
-        exclude 'com.amazonaws.opensearch.*/**'
-    }
-
+    relocate 'com.amazonaws', getShadowPath('com.amazonaws')
     relocate 'org.apache', getShadowPath('org.apache')
     relocate 'org.joda', getShadowPath('org.joda')
     relocate 'com.fasterxml', getShadowPath('com.fasterxml')
@@ -139,47 +136,59 @@ publishing {
             artifact javadocJar
 
             pom {
-              name = "OpenSearch SQL JDBC Driver"
-              packaging = "jar"
-              url = "https://github.com/opensearch-project/sql-jdbc"
-              description = "OpenSearch SQL JDBC driver"
-              scm {
-                connection = "scm:git@github.com:opensearch-project/sql-jdbc.git"
-                developerConnection = "scm:git@github.com:opensearch-project/sql-jdbc.git"
-                url = "git@github.com:opensearch-project/sql-jdbc.git"
-              }
-              licenses {
-                license {
-                  name = "The Apache License, Version 2.0"
-                  url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+                name = "OpenSearch SQL JDBC Driver"
+                packaging = "jar"
+                url = "https://github.com/opensearch-project/sql/sql-jdbc"
+                description = "OpenSearch SQL JDBC driver"
+                scm {
+                    connection = "scm:git@github.com:opensearch-project/sql.git"
+                    developerConnection = "scm:git@github.com:opensearch-project/sql.git"
+                    url = "git@github.com:opensearch-project/sql.git"
                 }
-              }
-              developers {
-                developer {
-                  id = "amazonwebservices"
-                  organization = "Amazon Web Services"
-                  organizationUrl = "https://aws.amazon.com"
+                licenses {
+                    license {
+                        name = "The Apache License, Version 2.0"
+                        url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+                    }
                 }
-              }
+                developers {
+                    developer {
+                        name = 'OpenSearch'
+                        url = 'https://github.com/opensearch-project/sql'
+                    }
+                }
+            }
+        }
+        publishMaven(MavenPublication) { publication ->
+            from components.java
+
+            pom {
+                name = "OpenSearch SQL JDBC Driver"
+                packaging = "jar"
+                url = "https://github.com/opensearch-project/sql/sql-jdbc"
+                description = "OpenSearch SQL JDBC driver"
+                scm {
+                    connection = "scm:git@github.com:opensearch-project/sql.git"
+                    developerConnection = "scm:git@github.com:opensearch-project/sql.git"
+                    url = "git@github.com:opensearch-project/sql.git"
+                }
+                licenses {
+                    license {
+                        name = "The Apache License, Version 2.0"
+                        url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+                    }
+                }
+                developers {
+                    developer {
+                        name = 'OpenSearch'
+                        url = 'https://github.com/opensearch-project/sql'
+                    }
+                }
             }
         }
     }
 
     repositories {
-        maven {
-            name = "internal-snapshots"
-            url = "s3://snapshots.opendistroforelasticsearch.amazon.com/maven"
-            authentication {
-                awsIm(AwsImAuthentication) // load from EC2 role or env var
-            }
-        }
-        maven {
-            name = "internal-releases"
-            url = "s3://artifacts.opendistroforelasticsearch.amazon.com/maven"
-            authentication {
-                awsIm(AwsImAuthentication) // load from EC2 role or env var
-            }
-        }
         maven {
             name = "sonatype-staging"
             url "https://aws.oss.sonatype.org/service/local/staging/deploy/maven2"
@@ -187,6 +196,10 @@ publishing {
                 username project.hasProperty('ossrhUsername') ? project.property('ossrhUsername') : ''
                 password project.hasProperty('ossrhPassword') ? project.property('ossrhPassword') : ''
             }
+        }
+        maven {
+            name = "localRepo"
+            url "${project.buildDir}/repository"
         }
     }
 

--- a/jenkins/jdbc-stage-maven-release.jenkinsfile
+++ b/jenkins/jdbc-stage-maven-release.jenkinsfile
@@ -1,0 +1,92 @@
+lib = library(identifier: 'jenkins@main', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/opensearch-project/opensearch-build.git',
+]))
+
+pipeline {
+    agent {
+        docker {
+            label 'Jenkins-Agent-AL2-X64-C54xlarge-Docker-Host'
+            image 'opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v2'
+            args '-e JAVA_HOME=/opt/java/openjdk-11'
+            alwaysPull true
+        }
+    }
+    options {
+        timeout(time: 30, unit: 'MINUTES')
+        throttleJobProperty(
+            categories: [],
+            limitOneJobWithMatchingParams: false,
+            maxConcurrentPerNode: 0,
+            maxConcurrentTotal: 1,
+            paramsToUseForLimit: '',
+            throttleEnabled: true,
+            throttleOption: 'project',
+        )
+    }
+    triggers {
+        GenericTrigger(
+            genericVariables: [
+                [key: 'ref', value: '$.ref'],
+                [key: 'VERSION', value: '$.ref', regexpFilter: 'refs/tags/v' ],
+            ],
+            tokenCredentialId: 'jenkins-sql-jdbc-generic-webhook-token',
+            causeString: 'A tag was cut on opensearch-project/sql repository causing this workflow to run',
+            printContributedVariables: false,
+            printPostContent: false,
+            regexpFilterText: '$ref',
+            regexpFilterExpression: '^sql-jdbc-release-[0-9\.]*$'
+        )
+    }
+    environment {
+        ARTIFACT_PATH = "$WORKSPACE/build/repository/org/opensearch/driver/opensearch-sql-jdbc/$VERSION"
+    }
+    stages {
+        stage('Publish to Maven Local') {
+            steps {
+                // checkout the commit
+                checkout([
+                    $class: 'GitSCM', userRemoteConfigs: [[url: 'https://github.com/opensearch-project/sql.git']],
+                    branches: [[name: "$ref"]]
+                        ])
+
+                dir('sql-jdbc') {
+                    // publish maven artifacts
+                    sh('./gradlew --no-daemon publishPublishMavenPublicationToLocalRepoRepository')
+                }
+            }
+        }
+        stage('Sign') {
+            steps {
+                script {
+                    signArtifacts(
+                        artifactPath: "${ARTIFACT_PATH}",
+                        type: 'maven',
+                        platform: 'linux'
+                    )
+                }
+            }
+        }
+        stage('Stage Maven Artifacts') {
+            environment {
+                REPO_URL = 'https://aws.oss.sonatype.org/'
+                STAGING_PROFILE_ID = "${SONATYPE_STAGING_PROFILE_ID}"
+                BUILD_ID = "${BUILD_NUMBER}"
+            }
+            steps {
+                // checkout the build repo
+                git url: 'https://github.com/opensearch-project/opensearch-build.git', branch: 'main'
+
+                // stage artifacts for release with Sonatype
+                withCredentials([usernamePassword(credentialsId: 'jenkins-sonatype-creds', usernameVariable: 'SONATYPE_USERNAME', passwordVariable: 'SONATYPE_PASSWORD')]) {
+                    sh('$WORKSPACE/publish/stage-maven-release.sh $WORKSPACE/build/repository/')
+                }
+            }
+        }
+    }
+    post {
+        always {
+            cleanWs disableDeferredWipeout: true, deleteDirs: true
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: Yury-Fridlyand <yury.fridlyand@improving.com>

### Description
Update `wiremock` and `jetty` which `wiremock` depends on.
Wiremock release: https://github.com/wiremock/wiremock/releases/tag/3.0.0-beta-2
Maven: https://mvnrepository.com/artifact/com.github.tomakehurst/wiremock/3.0.0-beta-2
Previous update: https://github.com/opensearch-project/sql/pull/872
Newer `jetty` activates SNI check, so I had to disable it, [ref](https://stackoverflow.com/questions/69945173/http-error-400-invalid-sni-jetty-https-servlet): https://github.com/Bit-Quill/sql-jdbc/blob/c3a79b79d58665d8fd3b69167c9a8fa9601a0467/src/test/java/org/opensearch/jdbc/test/TLSServer.java#L88-L90
 
### Issues Resolved
Closes #7 and #8
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).