### PR TITLE
Add release workflows

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,31 @@
+name: Release drafter
+
+# Push events to every tag not containing "/"
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  draft-a-release:
+    name: Draft a release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: 11
+          distribution: 'temurin'
+          cache: gradle
+      - name: Build with Gradle
+        run: |
+          ./gradlew publishPublishMavenPublicationToLocalRepoRepository && tar -C build -cvf artifacts.tar.gz repository
+      - name: Draft a release
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          generate_release_notes: true
+          files: |
+            artifacts.tar.gz

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -19,7 +19,7 @@ Given the current major release of 1.0, projects in this organization maintain t
 * **1.x**: The next _minor_ release. Once a change is merged into `main`, decide whether to backport it to `1.x`.
 * **1.0**: The _current_ release. In between minor releases, only hotfixes (e.g. security) are backported to `1.0`.
 
-Label PRs with the next major version label (e.g. `2.0.0`) and merge changes into `main`. Label PRs that you believe need to be backported as `1.x` and `1.0`. Backport PRs by checking out the versioned branch, cherry-pick changes and open a PR against each target backport branch.
+Label PRs with the next major version label (e.g. `v2.0.0`) and merge changes into `main`. Label PRs that you believe need to be backported as `backport 1.x` and `backport 1.0`. Backport PRs by checking out the versioned branch, cherry-pick changes and open a PR against each target backport branch.
 
 ### Feature Branches
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -19,7 +19,7 @@ Given the current major release of 1.0, projects in this organization maintain t
 * **1.x**: The next _minor_ release. Once a change is merged into `main`, decide whether to backport it to `1.x`.
 * **1.0**: The _current_ release. In between minor releases, only hotfixes (e.g. security) are backported to `1.0`.
 
-Label PRs with the next major version label (e.g. `v2.0.0`) and merge changes into `main`. Label PRs that you believe need to be backported as `backport 1.x` and `backport 1.0`. Backport PRs by checking out the versioned branch, cherry-pick changes and open a PR against each target backport branch.
+Label PRs with the next major version label (e.g. `v2.0.0.0`) and merge changes into `main`. Label PRs that you believe need to be backported as `backport 1.x` and `backport 1.0`. Backport PRs by checking out the versioned branch, cherry-pick changes and open a PR against each target backport branch.
 
 ### Feature Branches
 
@@ -33,8 +33,8 @@ Repositories create consistent release labels, such as `v1.0.0`, `v1.1.0` and `v
 
 The release process is standard across repositories in this org and is run by a release manager volunteering from amongst [maintainers](MAINTAINERS.md).
 
-1. Create a tag, e.g. 1.0.0, and push it to this GitHub repository.
+1. Create a tag, e.g. 1.0.0.0, and push it to this GitHub repository.
 1. The [release-drafter.yml](.github/workflows/release-drafter.yml) will be automatically kicked off and a draft release will be created.
 1. This draft release triggers the [jenkins release workflow](https://build.ci.opensearch.org/job/sql-jdbc-release) as a result of which the driver is released on [maven central](https://search.maven.org/search?q=org.opensearch.driver). Please note that the release workflow is triggered only if created release is in draft state.
 1. Once the above release workflow is successful, the drafted release on GitHub is published automatically.
-1. Increment "version" in [build.gradle](./build.gradle) to the next iteration, e.g. v2.1.1. See [example](https://github.com/opensearch-project/sql-jdbc/pull/11).
+1. Increment "version" in [build.gradle](./build.gradle) to the next iteration, e.g. 1.0.0.1 See [example](https://github.com/opensearch-project/sql-jdbc/pull/11).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,40 @@
+- [Overview](#overview)
+- [Branching](#branching)
+  - [Release Branching](#release-branching)
+  - [Feature Branches](#feature-branches)
+- [Release Labels](#release-labels)
+- [Releasing](#releasing)
+
+## Overview
+
+This document explains the release strategy for artifacts in this organization.
+
+## Branching
+
+### Release Branching
+
+Given the current major release of 1.0, projects in this organization maintain the following active branches.
+
+* **main**: The next _major_ release. This is the branch where all merges take place and code moves fast.
+* **1.x**: The next _minor_ release. Once a change is merged into `main`, decide whether to backport it to `1.x`.
+* **1.0**: The _current_ release. In between minor releases, only hotfixes (e.g. security) are backported to `1.0`.
+
+Label PRs with the next major version label (e.g. `2.0.0`) and merge changes into `main`. Label PRs that you believe need to be backported as `1.x` and `1.0`. Backport PRs by checking out the versioned branch, cherry-pick changes and open a PR against each target backport branch.
+
+### Feature Branches
+
+Do not create branches in the upstream repo, use your fork, for the exception of long lasting feature branches that require active collaboration from multiple developers. Name feature branches `feature/<thing>`. Once the work is merged to `main`, please make sure to delete the feature branch.
+
+## Release Labels
+
+Repositories create consistent release labels, such as `v1.0.0`, `v1.1.0` and `v2.0.0`, as well as `patch` and `backport`. Use release labels to target an issue or a PR for a given release.
+
+## Releasing
+
+The release process is standard across repositories in this org and is run by a release manager volunteering from amongst [maintainers](MAINTAINERS.md).
+
+1. Create a tag, e.g. 1.0.0, and push it to this GitHub repository.
+1. The [release-drafter.yml](.github/workflows/release-drafter.yml) will be automatically kicked off and a draft release will be created.
+1. This draft release triggers the [jenkins release workflow](https://build.ci.opensearch.org/job/sql-jdbc-release) as a result of which the driver is released on [maven central](https://search.maven.org/search?q=org.opensearch.driver). Please note that the release workflow is triggered only if created release is in draft state.
+1. Once the above release workflow is successful, the drafted release on GitHub is published automatically.
+1. Increment "version" in [build.gradle](./build.gradle) to the next iteration, e.g. v2.1.1. See [example](https://github.com/opensearch-project/sql-jdbc/pull/11).

--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -1,0 +1,16 @@
+lib = library(identifier: 'jenkins@1.5.3', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
+]))
+
+standardReleasePipelineWithGenericTrigger(
+    tokenIdCredential: 'jenkins-sql-jdbc-generic-webhook-token',
+    causeString: 'A tag was cut on opensearch-project/sql-jdbc repository causing this workflow to run',
+    downloadReleaseAsset: true,
+    publishRelease: true) {
+        publishToMaven(
+            signingArtifactsPath: "$WORKSPACE/repository/",
+            mavenArtifactsPath: "$WORKSPACE/repository/",
+            autoPublish: true
+        )
+    }


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
This change adds the release workflow which includes a release-drafter that drafters a release with all artifacts that needs to be published attached to it. It also contains a jenkins workflow that is responsible for signing and publishing the artifacts to maven central.
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/2692
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).