### PR TITLE
[Backport 2.x] Update `wiremock` and `jetty`. (#46)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,11 +51,11 @@ dependencies {
 
     testImplementation('org.junit.jupiter:junit-jupiter-api:5.3.1')
     testImplementation('org.junit.jupiter:junit-jupiter-params:5.3.1')
-    testImplementation('com.github.tomakehurst:wiremock-jre8-standalone:2.34.0')
+    testImplementation('com.github.tomakehurst:wiremock:3.0.0-beta-2')
     testImplementation('org.mockito:mockito-core:2.23.0')
     testImplementation('org.junit.jupiter:junit-jupiter-engine:5.3.1')
     testImplementation('org.junit-pioneer:junit-pioneer:0.3.0')
-    testImplementation('org.eclipse.jetty:jetty-server:9.4.48.v20220622')
+    testImplementation('org.eclipse.jetty:jetty-server:11.0.12')
 
     // Enforce wiremock to use latest guava
     testImplementation('com.google.guava:guava:31.1-jre')

--- a/src/test/java/org/opensearch/jdbc/test/TLSServer.java
+++ b/src/test/java/org/opensearch/jdbc/test/TLSServer.java
@@ -6,6 +6,8 @@
 
 package org.opensearch.jdbc.test;
 
+import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.SslConnectionFactory;
 import org.opensearch.jdbc.internal.util.UrlParser;
 import org.opensearch.jdbc.test.mocks.MockOpenSearch;
 import org.eclipse.jetty.server.ConnectionFactory;
@@ -20,9 +22,9 @@ import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.ServletException;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 public class TLSServer {
@@ -83,17 +85,19 @@ public class TLSServer {
         sslContextFactory.setNeedClientAuth(needClientAuth);
 
         HttpConfiguration httpConfig = new HttpConfiguration();
-        httpConfig.addCustomizer(new SecureRequestCustomizer());
+        SecureRequestCustomizer src = new SecureRequestCustomizer();
+        src.setSniHostCheck(false);
+        httpConfig.addCustomizer(src);
 
         httpsConnector = createServerConnector(
                 jettyServer,
                 host,
                 0,
-                new org.eclipse.jetty.server.SslConnectionFactory(
+                new SslConnectionFactory(
                         sslContextFactory,
                         "http/1.1"
                 ),
-                new org.eclipse.jetty.server.HttpConnectionFactory(httpConfig)
+                new HttpConnectionFactory(httpConfig)
         );
 
         jettyServer.addConnector(httpsConnector);


### PR DESCRIPTION
Signed-off-by: Yury-Fridlyand <yury.fridlyand@improving.com>

Signed-off-by: Yury-Fridlyand <yury.fridlyand@improving.com>
(cherry picked from commit d932fba740f73dc6bb0b6e87d3ebbfbf66fe4900)
Signed-off-by: Yury-Fridlyand <yury.fridlyand@improving.com>

### Description
Backport #46 to `2.x`
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).