### PR TITLE
Update `SHOW` and `DESCRIBE` queries.

### DIFF
--- a/src/main/java/org/opensearch/jdbc/DatabaseMetaDataImpl.java
+++ b/src/main/java/org/opensearch/jdbc/DatabaseMetaDataImpl.java
@@ -671,12 +671,12 @@ public class DatabaseMetaDataImpl implements DatabaseMetaData, JdbcWrapper, Logg
 
     @Override
     public ResultSet getTables(String catalog, String schemaPattern, String tableNamePattern, String[] types) throws SQLException {
-        // TODO - when server plugin supports PreparedStatement fully, implement this as a preparedStatment with params
+        // TODO - when server plugin supports PreparedStatement fully, implement this as a preparedStatement with params
         log.debug(() -> logMessage("getTables(%s, %s, %s, %s)",
                 catalog, schemaPattern, tableNamePattern, Arrays.toString(types)));
 
-        PreparedStatement pst = connection.prepareStatement("SHOW TABLES LIKE " +
-                (tableNamePattern == null ? "%" : tableNamePattern));
+        PreparedStatement pst = connection.prepareStatement("SHOW TABLES LIKE '" +
+                (tableNamePattern == null ? "%" : tableNamePattern) + "'");
 
         ResultSet resultSet = pst.executeQuery();
 
@@ -1207,8 +1207,8 @@ public class DatabaseMetaDataImpl implements DatabaseMetaData, JdbcWrapper, Logg
         ColumnMetadataStatement(ConnectionImpl connection, String tableNamePattern, String columnNamePattern, Logger log)
                 throws SQLException {
             // TODO - once sql plugin supports PreparedStatement fully, do this through a preparedStatement with params
-            super(connection, "DESCRIBE TABLES LIKE " + tableNamePattern +
-                (columnNamePattern != null ? (" COLUMNS LIKE " + columnNamePattern) : ""),
+            super(connection, "DESCRIBE TABLES LIKE '" + tableNamePattern +
+                (columnNamePattern != null ? (" COLUMNS LIKE '" + columnNamePattern + "'") : "'"),
                 log);
         }
 


### PR DESCRIPTION
### Description
As of https://github.com/opensearch-project/sql/pull/1181, `SHOW` and `DESCRIBE` queries syntax changed in V2. These query were falling back to V1 SQL plugin engine, which would be deprecated once upon a time. Updating this query in JDBC driver ensures that SQL plugin would properly respond to it.
See similar fix in ODBC: https://github.com/opensearch-project/sql-odbc/pull/48.

### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).