### PR TITLE
Add functions for date type in the TACO (#5)

### DIFF
--- a/bi-connectors/TableauConnector/src/dialect.tdd
+++ b/bi-connectors/TableauConnector/src/dialect.tdd
@@ -87,6 +87,11 @@
             <argument type='date' />
             <argument type='datetime' />
         </function>
+        <function group='operator' name='==' return-type='bool'>
+            <formula>(%1 = %2)</formula>
+            <argument type='date' />
+            <argument type='date' />
+        </function>
         <function group='operator' name='!=' return-type='bool'>
             <formula>(%1 AND NOT %2 OR NOT %1 AND %2)</formula>
             <argument type='bool' />
@@ -127,6 +132,11 @@
             <argument type='datetime' />
             <argument type='date' />
         </function>
+        <function group='operator' name='!=' return-type='bool'>
+            <formula>(%1 &lt;&gt; %2)</formula>
+            <argument type='date' />
+            <argument type='date' />
+        </function>
         <function group='operator' name='&gt;' return-type='bool'>
             <formula>(%1 &gt; CAST(DATE_FORMAT(%2, '%Y-%m-%d 00:00:00') AS TIMESTAMP))</formula>
             <argument type='datetime' />
@@ -136,6 +146,11 @@
             <formula>(CAST(DATE_FORMAT(%1, '%Y-%m-%d 00:00:00') AS TIMESTAMP)  &gt; %2)</formula>
             <argument type='date' />
             <argument type='datetime' />
+        </function>
+        <function group='operator' name='&gt;' return-type='bool'>
+            <formula>(%1 &gt; %2)</formula>
+            <argument type='date' />
+            <argument type='date' />
         </function>
         <function group='operator' name='&gt;=' return-type='bool'>
             <formula>(%1 &gt;= CAST(DATE_FORMAT(%2, '%Y-%m-%d 00:00:00') AS TIMESTAMP))</formula>
@@ -147,6 +162,11 @@
             <argument type='date' />
             <argument type='datetime' />
         </function>
+        <function group='operator' name='&gt;=' return-type='bool'>
+            <formula>(%1 &gt;= %2)</formula>
+            <argument type='date' />
+            <argument type='date' />
+        </function>
         <function group='operator' name='&lt;' return-type='bool'>
             <formula>(%1 &lt; CAST(DATE_FORMAT(%2, '%Y-%m-%d 00:00:00') AS TIMESTAMP))</formula>
             <argument type='datetime' />
@@ -156,6 +176,11 @@
             <formula>(CAST(DATE_FORMAT(%1, '%Y-%m-%d 00:00:00') AS TIMESTAMP)  &lt; %2)</formula>
             <argument type='date' />
             <argument type='datetime' />
+        </function>
+        <function group='operator' name='&lt;' return-type='bool'>
+            <formula>(%1 &lt; %2)</formula>
+            <argument type='date' />
+            <argument type='date' />
         </function>
         <function group='operator' name='&lt;=' return-type='bool'>
             <formula>(%1 &lt;= CAST(DATE_FORMAT(%2, '%Y-%m-%d 00:00:00') AS TIMESTAMP))</formula>
@@ -167,10 +192,26 @@
             <argument type='date' />
             <argument type='datetime' />
         </function>
+        <function group='operator' name='&lt;=' return-type='bool'>
+            <formula>(%1 &lt;= %2)</formula>
+            <argument type='date' />
+            <argument type='date' />
+        </function>
         <function group='operator' name='+' return-type='datetime'>
             <!-- 86400 as it represents seconds in a day -->
             <formula>DATE_ADD(%1, INTERVAL CAST((86400 * %2) AS INT) SECOND)</formula>
             <argument type='datetime' />
+            <argument type='real' />
+        </function>
+        <function group='operator' name='+' return-type='datetime'>
+            <formula>DATE_ADD(%1, INTERVAL %2 DAY)</formula>
+            <argument type='date' />
+            <argument type='int' />
+        </function>
+        <function group='operator' name='+' return-type='datetime'>
+            <!-- 86400 as it represents seconds in a day -->
+            <formula>DATE_ADD(%1, INTERVAL CAST((86400 * %2) AS INT) SECOND)</formula>
+            <argument type='date' />
             <argument type='real' />
         </function>
         <function group='operator' name='-' return-type='int'>
@@ -189,13 +230,13 @@
         </function>
         <function group='operator' name='-' return-type='real'>
             <!-- 86400 as it represents seconds in a day -->
-            <formula>((TO_DAYS(%1) - TO_DAYS(CAST(DATE_FORMAT(%2, '%Y-%m-%d 00:00:00') AS TIMESTAMP))) + ((TIME_TO_SEC(%1) - TIME_TO_SEC(CAST(DATE_FORMAT(%2, '%Y-%m-%d 00:00:00') AS TIMESTAMP))) / 86400.0))</formula>
+            <formula>(unix_timestamp(%1) - unix_timestamp(%2)) / 86400</formula>
             <argument type='datetime' />
             <argument type='date' />
         </function>
         <function group='operator' name='-' return-type='real'>
             <!-- 86400 as it represents seconds in a day -->
-            <formula>((TO_DAYS(CAST(DATE_FORMAT(%1, '%Y-%m-%d 00:00:00') AS TIMESTAMP))) - TO_DAYS(%1) + ((TIME_TO_SEC(CAST(DATE_FORMAT(%1, '%Y-%m-%d 00:00:00') AS TIMESTAMP)) - TIME_TO_SEC(%2)) / 86400.0))</formula>
+            <formula>(unix_timestamp(%1) - unix_timestamp(%2)) / 86400</formula>
             <argument type='date' />
             <argument type='datetime' />
         </function>
@@ -204,6 +245,22 @@
             <formula>DATE_SUB(%1, INTERVAL CAST((86400 * %2) AS INT) SECOND)</formula>
             <argument type='datetime' />
             <argument type='real' />
+        </function>
+        <function group='operator' name='-' return-type='datetime'>
+            <formula>DATE_SUB(%1, INTERVAL %2 DAY)</formula>
+            <argument type='date' />
+            <argument type='int' />
+        </function>
+        <function group='operator' name='-' return-type='datetime'>
+            <!-- 86400 as it represents seconds in a day -->
+            <formula>DATE_SUB(%1, INTERVAL CAST((86400 * %2) AS INT) SECOND)</formula>
+            <argument type='date' />
+            <argument type='real' />
+        </function>
+        <function group='operator' name='-' return-type='real'>
+            <formula>TO_DAYS(%1) - TO_DAYS(%2)</formula>
+            <argument type='date' />
+            <argument type='date' />
         </function>
         <function group='operator' name='/' return-type='real'>
             <formula>CAST(%1 AS DOUBLE) / %2</formula>
@@ -262,6 +319,14 @@
             <argument type='datetime' />
             <argument type='datetime' />
         </function>
+        <function group='numeric' name='MAX' return-type='date'>
+            <formula>CASE WHEN ISNULL(%1) THEN NULL
+                WHEN ISNULL(%2) THEN NULL
+                WHEN %1 &gt; %2 THEN %1
+                ELSE %2 END</formula>
+            <argument type='date' />
+            <argument type='date' />
+        </function>
         <function group='numeric' name='MAX' return-type='str'>
             <formula>CASE WHEN ISNULL(%1) THEN NULL
                 WHEN ISNULL(%2) THEN NULL
@@ -293,6 +358,14 @@
                 ELSE %2 END</formula>
             <argument type='datetime' />
             <argument type='datetime' />
+        </function>
+        <function group='numeric' name='MIN' return-type='date'>
+            <formula>CASE WHEN ISNULL(%1) THEN NULL
+                WHEN ISNULL(%2) THEN NULL
+                WHEN %1 &lt; %2 THEN %1
+                ELSE %2 END</formula>
+            <argument type='date' />
+            <argument type='date' />
         </function>
         <function group='numeric' name='MIN' return-type='str'>
             <formula>CASE WHEN ISNULL(%1) THEN NULL

--- a/bi-connectors/TableauConnector/src/manifest.xml
+++ b/bi-connectors/TableauConnector/src/manifest.xml
@@ -2,8 +2,8 @@
 
 <connector-plugin class='opensearch_jdbc' superclass='jdbc' plugin-version='2.0.0.0' name='OpenSearch' version='18.1' min-version-tableau='2021.1'>
   <vendor-information>
-      <company name="OpenSearch Project"/>
-      <support-link url="https://forum.opensearch.org/"/>
+    <company name="OpenSearch Project"/>
+    <support-link url="https://forum.opensearch.org/"/>
   </vendor-information>
   <connection-customization class="opensearch_jdbc" enabled="true" version="10.0">
     <vendor name="OpenSearch Project"/>
@@ -26,7 +26,7 @@
       <customization name="CAP_SUPPORTS_SPLIT_FROM_LEFT" value="yes"/>
       <customization name="CAP_SUPPORTS_SPLIT_FROM_RIGHT" value="yes"/>
       <customization name="CAP_QUERY_ALLOW_PARTIAL_AGGREGATION" value="no"/>
-      <customization name="CAP_QUERY_TIME_REQUIRES_CAST" value="yes"/>
+      <customization name="CAP_QUERY_TIME_REQUIRES_CAST" value="no"/>
       <customization name="CAP_JDBC_METADATA_USE_RESULTSET_FOR_TABLE" value="yes"/>
       <customization name="CAP_JDBC_METADATA_GET_INDEX_INFO" value="no"/>
       <customization name="CAP_JDBC_METADATA_IGNORE_NULLABILITY" value="yes"/>


### PR DESCRIPTION
### Description
The manifest file change allows for Tableau to use time columns without having to cast. 
The dialect file changes fixes and supports the following test files and test cases:


TestPath | Test Case
-- | --
/opt/homebrew/lib/python3.11/site-packages/tdvt/logicaltests/setup/calcs/setup.Filter.Date_In.simple_lower.xml |  
/opt/homebrew/lib/python3.11/site-packages/tdvt/logicaltests/setup/calcs/setup.Filter.Date_In_Time.simple_lower.xml |  
/opt/homebrew/lib/python3.11/site-packages/tdvt/exprtests/standard/setup.calcs_data.time.txt | time1
/opt/homebrew/lib/python3.11/site-packages/tdvt/exprtests/standard/setup.date.math.date_minus_date.txt | [date2] - [date2]
/opt/homebrew/lib/python3.11/site-packages/tdvt/exprtests/standard/setup.operator.date.equality.txt | date0 == 7/4/1972
/opt/homebrew/lib/python3.11/site-packages/tdvt/exprtests/standard/setup.operator.date.gt.txt | date0 > 11/12/1975
/opt/homebrew/lib/python3.11/site-packages/tdvt/exprtests/standard/setup.operator.date.gte.txt | date0 >= 11/12/1975
/opt/homebrew/lib/python3.11/site-packages/tdvt/exprtests/standard/setup.operator.date.lt.txt | date0 < 11/12/1975
/opt/homebrew/lib/python3.11/site-packages/tdvt/exprtests/standard/setup.operator.date.lte.txt | date0 <= 11/12/1975
/opt/homebrew/lib/python3.11/site-packages/tdvt/exprtests/standard/setup.operator.date.minus_datetime.txt | date0 - datetime0
/opt/homebrew/lib/python3.11/site-packages/tdvt/exprtests/standard/setup.operator.date.not_equal.txt | date0 != 11/12/1975
/opt/homebrew/lib/python3.11/site-packages/tdvt/exprtests/standard/setup.date.max.txt | MAX([date2], [date3])
/opt/homebrew/lib/python3.11/site-packages/tdvt/exprtests/standard/setup.date.min.txt | MIN([date2], [date3])
/opt/homebrew/lib/python3.11/site-packages/tdvt/exprtests/standard/setup.date.B639952.txt | SUM([date0]-1-[date1])
/opt/homebrew/lib/python3.11/site-packages/tdvt/exprtests/standard/setup.date.B639952.txt | SUM([date0]+300-[date1])
/opt/homebrew/lib/python3.11/site-packages/tdvt/exprtests/standard/setup.date.B639952.txt | [date0]-([date1]-1-[date2])
/opt/homebrew/lib/python3.11/site-packages/tdvt/exprtests/standard/setup.date.B639952.txt | [date1]-([date3]+500-[date2])
/opt/homebrew/lib/python3.11/site-packages/tdvt/exprtests/standard/setup.date.B639952.txt | [date1]-([date3]+500-[date2])+([date3]-[date0])
/opt/homebrew/lib/python3.11/site-packages/tdvt/exprtests/standard/setup.date.B639952.txt | SUM(([date3]-400-[date0])+([date3]+500-[date2]))
/opt/homebrew/lib/python3.11/site-packages/tdvt/exprtests/standard/setup.date.B639952.txt | SUM([date3]-1-(date(dateadd('month', 3, 2004-04-15 )))+1)
/opt/homebrew/lib/python3.11/site-packages/tdvt/exprtests/standard/setup.date.math.txt | [date2] =  [date2]
/opt/homebrew/lib/python3.11/site-packages/tdvt/exprtests/standard/setup.date.math.txt | [date2] >  [date2]
/opt/homebrew/lib/python3.11/site-packages/tdvt/exprtests/standard/setup.date.math.txt | [date2] >= [date2]
/opt/homebrew/lib/python3.11/site-packages/tdvt/exprtests/standard/setup.date.math.txt | [date2] <  [date2]
/opt/homebrew/lib/python3.11/site-packages/tdvt/exprtests/standard/setup.date.math.txt | [date2] <= [date2]
/opt/homebrew/lib/python3.11/site-packages/tdvt/exprtests/standard/setup.date.math.txt | [date2] <> [date2]
/opt/homebrew/lib/python3.11/site-packages/tdvt/exprtests/standard/setup.logical.txt | min(date0,date1)



 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).