### PR TITLE
Added brackets for math operation functions in the TACO

### DIFF
--- a/bi-connectors/TableauConnector/src/dialect.tdd
+++ b/bi-connectors/TableauConnector/src/dialect.tdd
@@ -199,7 +199,7 @@
         </function>
         <function group='operator' name='+' return-type='datetime'>
             <!-- 86400 as it represents seconds in a day -->
-            <formula>DATE_ADD(%1, INTERVAL CAST((86400 * %2) AS INT) SECOND)</formula>
+            <formula>DATE_ADD(%1, INTERVAL CAST((86400 * (%2)) AS INT) SECOND)</formula>
             <argument type='datetime' />
             <argument type='real' />
         </function>
@@ -210,16 +210,16 @@
         </function>
         <function group='operator' name='+' return-type='datetime'>
             <!-- 86400 as it represents seconds in a day -->
-            <formula>DATE_ADD(%1, INTERVAL CAST((86400 * %2) AS INT) SECOND)</formula>
+            <formula>DATE_ADD(%1, INTERVAL CAST((86400 * (%2)) AS INT) SECOND)</formula>
             <argument type='date' />
             <argument type='real' />
         </function>
         <function group='operator' name='-' return-type='int'>
-            <formula>(%1 * -1)</formula>
+            <formula>((%1) * -1)</formula>
             <argument type='int' />
         </function>
         <function group='operator' name='-' return-type='real'>
-            <formula>(%1 * -1)</formula>
+            <formula>((%1) * -1)</formula>
             <argument type='real' />
         </function>
         <function group='operator' name='-' return-type='real'>
@@ -242,7 +242,7 @@
         </function>
         <function group='operator' name='-' return-type='datetime'>
             <!-- 86400 as it represents seconds in a day -->
-            <formula>DATE_SUB(%1, INTERVAL CAST((86400 * %2) AS INT) SECOND)</formula>
+            <formula>DATE_SUB(%1, INTERVAL CAST((86400 * (%2)) AS INT) SECOND)</formula>
             <argument type='datetime' />
             <argument type='real' />
         </function>
@@ -253,7 +253,7 @@
         </function>
         <function group='operator' name='-' return-type='datetime'>
             <!-- 86400 as it represents seconds in a day -->
-            <formula>DATE_SUB(%1, INTERVAL CAST((86400 * %2) AS INT) SECOND)</formula>
+            <formula>DATE_SUB(%1, INTERVAL CAST((86400 * (%2)) AS INT) SECOND)</formula>
             <argument type='date' />
             <argument type='real' />
         </function>
@@ -263,7 +263,7 @@
             <argument type='date' />
         </function>
         <function group='operator' name='/' return-type='real'>
-            <formula>CAST(%1 AS DOUBLE) / %2</formula>
+            <formula>CAST(%1 AS DOUBLE) / (%2)</formula>
             <argument type='int' />
             <argument type='int' />
         </function>
@@ -273,12 +273,12 @@
             <argument type="real" />
         </function>
         <function group='numeric' name='DIV' return-type='int'>
-            <formula>CASE WHEN %2 = 0 THEN NULL ELSE ( %1 / %2 ) END</formula>
+            <formula>CASE WHEN %2 = 0 THEN NULL ELSE ( (%1) / (%2) ) END</formula>
             <argument type='int' />
             <argument type='int' />
         </function>
         <function group='numeric' name='DIV' return-type='real'>
-            <formula>CASE WHEN %2 = 0 THEN NULL ELSE ( %1 / %2 ) END</formula>
+            <formula>CASE WHEN %2 = 0 THEN NULL ELSE ( (%1) / (%2) ) END</formula>
             <argument type='real' />
             <argument type='real' />
         </function>


### PR DESCRIPTION
### Description
Test failures in TDVT were caused by unexpected order of operations. 
For formula `86400 * x` with `x = TO_DAYS(date1) - TO_DAYS(date2)` we get `86400 * TO_DAYS(date1) - TO_DAYS(date2)` instead of `86400 * (TO_DAYS(date1) - TO_DAYS(date2))`.

Brackets were added to function arguments for math operations in order to fix this issue.
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).