### PR TITLE
Replaced autobuild workflow to fix CI

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,8 +36,7 @@ jobs:
     # allows for java 8 and java 11 to be used.
     # https://github.com/opensearch-project/sql-jdbc/pull/96#issuecomment-1611181743
     - name: Build
-      run: |
-        ./gradlew --no-daemon -S -Dorg.gradle.dependency.verification=off clean
+      run:
         ./gradlew --no-daemon -S -Dorg.gradle.dependency.verification=off testClasses
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,10 +32,12 @@ jobs:
       uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
-        # using v2.13.3 due to a breaking change in codeql https://github.com/github/codeql/issues/13541
-        tools: 'https://github.com/github/codeql-action/releases/download/codeql-bundle-v2.13.3/codeql-bundle-linux64.tar.gz'
 
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+    # allows for java 8 and java 11 to be used.
+    # https://github.com/opensearch-project/sql-jdbc/pull/96#issuecomment-1611181743
+    - name: Build
+      run: |
+        ./gradlew --no-daemon -S -Dorg.gradle.dependency.verification=off clean
+        ./gradlew --no-daemon -S -Dorg.gradle.dependency.verification=off testClasses
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/release-notes/opensearch-jdbc-release-notes-1.4.0.0.md
+++ b/release-notes/opensearch-jdbc-release-notes-1.4.0.0.md
@@ -22,3 +22,4 @@ connector-release-notes-1.0.0.0.md).
 * Update CI workflows. ([#87](https://github.com/opensearch-project/sql-jdbc/pull/87))
 * Update release notes. ([#88](https://github.com/opensearch-project/sql-jdbc/pull/88))
 * Fix H2 and guava CVEs. ([#96](https://github.com/opensearch-project/sql-jdbc/pull/96))
+* Replaced autobuild workflow to fix CI. ([#100](https://github.com/opensearch-project/sql-jdbc/pull/100))


### PR DESCRIPTION
### Description
Replaced autobuild workflow to prevent using a specific version of codeQL. Changes from suggested solution in https://github.com/opensearch-project/sql-jdbc/pull/96#issuecomment-1611181743
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).