### PR TITLE
Make driver throw SQLSTATE 28000 for invalid username or password 

### DIFF
--- a/release-notes/opensearch-jdbc-release-notes-1.4.0.0.md
+++ b/release-notes/opensearch-jdbc-release-notes-1.4.0.0.md
@@ -23,3 +23,4 @@ connector-release-notes-1.0.0.0.md).
 * Update release notes. ([#88](https://github.com/opensearch-project/sql-jdbc/pull/88))
 * Fix H2 and guava CVEs. ([#96](https://github.com/opensearch-project/sql-jdbc/pull/96))
 * Replaced autobuild workflow to fix CI. ([#100](https://github.com/opensearch-project/sql-jdbc/pull/100))
+* Make driver throw SQLSTATE 28000 for invalid username or password. ([#102](https://github.com/opensearch-project/sql-jdbc/pull/102))


### PR DESCRIPTION
### Description
This change throws SQLSTATE 28000 for invalid username or password which is [required by Tableau](https://tableau.github.io/connector-plugin-sdk/docs/manual-test#:~:text=Connect%20to%20the%20correct%20database%20with%20the%20wrong%20credentials). This only covers 401 responses, responses like 403 from SIGV4 returns a different message.

Before:
<img width="548" alt="Screenshot 2023-06-15 at 11 20 50 AM" src="https://github.com/opensearch-project/sql-jdbc/assets/29149268/cf00a8d9-c573-45bf-b6b1-c880f28db6fe">

After:
<img width="548" alt="Screenshot 2023-06-21 at 3 30 51 PM" src="https://github.com/Bit-Quill/sql-jdbc/assets/29149268/4f12f5cf-980b-43e6-a9c7-6f9dc8d3760f">
 
### Issues Resolved
https://github.com/opensearch-project/sql-jdbc/issues/95
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).