### PR TITLE
Remove publish to maven for now

### DIFF
--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -9,11 +9,11 @@ standardReleasePipelineWithGenericTrigger(
     causeString: 'A tag was cut on opensearch-project/sql-jdbc repository causing this workflow to run',
     downloadReleaseAsset: true,
     publishRelease: true) {
-        publishToMaven(
-            signingArtifactsPath: "$WORKSPACE/repository/",
-            mavenArtifactsPath: "$WORKSPACE/repository/",
-            autoPublish: true
-        )
+//         publishToMaven(
+//             signingArtifactsPath: "$WORKSPACE/repository/",
+//             mavenArtifactsPath: "$WORKSPACE/repository/",
+//             autoPublish: true
+//         )
         publishToArtifactsProdBucket(
             assumedRoleName: 'sql-jdbc-upload-role',
             source: "$WORKSPACE/shadowJar/opensearch-sql-jdbc-shadow-${tag}.jar",


### PR DESCRIPTION
### Description
Remove publishing to maven so that we can release shadow jar
 
### Issues Resolved
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).