### PR TITLE
Bump jenkins lib version to accomodate signer changes

### DIFF
--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -1,4 +1,4 @@
-lib = library(identifier: 'jenkins@5.6.1', retriever: modernSCM([
+lib = library(identifier: 'jenkins@5.7.0', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))


### PR DESCRIPTION
### Description
The signer library under the hood uses bourne shell as default shell causing `jarsigner` to be not found here https://build.ci.opensearch.org/view/Release/job/sql-jdbc-release/9/console
This change bumps the version where the above bug is fixed. Related PR: https://github.com/opensearch-project/opensearch-build-libraries/pull/294
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).