### PR TITLE
[CVE] Bump the jackson-databind from `2.13.5` to `2.15.0`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ repositories {
 
 dependencies {
     implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "2.13.5"
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "2.14.2"
     implementation group: 'com.amazonaws', name: 'aws-java-sdk-core', version: '1.12.651'
 
     testImplementation('org.junit.jupiter:junit-jupiter-api:5.3.1')

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ repositories {
 
 dependencies {
     implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "2.14.2"
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "2.15.0"
     implementation group: 'com.amazonaws', name: 'aws-java-sdk-core', version: '1.12.651'
 
     testImplementation('org.junit.jupiter:junit-jupiter-api:5.3.1')


### PR DESCRIPTION
### Description
Bunp the jackson-databind from `2.13.5` to `2.15.0`
 
### Issues Resolved
* Resolve https://github.com/opensearch-project/sql-jdbc/issues/137
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).