### PR TITLE
opensearch-project/sql-jdbc#22 AWS IAM access keys properties

### DIFF
--- a/src/main/java/org/opensearch/jdbc/config/AwsAccessKeyProperty.java
+++ b/src/main/java/org/opensearch/jdbc/config/AwsAccessKeyProperty.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.jdbc.config;
+
+public class AwsAccessKeyProperty extends StringConnectionProperty {
+
+    public static final String KEY = "awsAccessKey";
+
+    public AwsAccessKeyProperty() {
+        super(KEY);
+    }
+}

--- a/src/main/java/org/opensearch/jdbc/config/AwsSecretKeyProperty.java
+++ b/src/main/java/org/opensearch/jdbc/config/AwsSecretKeyProperty.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.jdbc.config;
+
+public class AwsSecretKeyProperty extends StringConnectionProperty {
+
+    public static final String KEY = "awsSecretKey";
+
+    public AwsSecretKeyProperty() {
+        super(KEY);
+    }
+}

--- a/src/main/java/org/opensearch/jdbc/config/AwsSessionTokenProperty.java
+++ b/src/main/java/org/opensearch/jdbc/config/AwsSessionTokenProperty.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.jdbc.config;
+
+public class AwsSessionTokenProperty extends StringConnectionProperty {
+
+    public static final String KEY = "awsSessionToken";
+
+    public AwsSessionTokenProperty() {
+        super(KEY);
+    }
+}

--- a/src/main/java/org/opensearch/jdbc/config/ConnectionConfig.java
+++ b/src/main/java/org/opensearch/jdbc/config/ConnectionConfig.java
@@ -223,9 +223,9 @@ public class ConnectionConfig {
                 ", requestCompression=" + requestCompression +
                 ", authenticationType=" + authenticationType +
                 ", awsCredentialsProvider=" + awsCredentialsProvider +
-            ", awsCredentialsProvider=" + awsCredentialsProvider +
-            ", awsCredentialsProvider=" + awsCredentialsProvider +
-            ", awsCredentialsProvider=" + awsCredentialsProvider +
+                ", awsAccessKey=" + awsAccessKey +
+                ", awsSecretKey=" + awsSecretKey +
+                ", awsSessionToken=" + awsSessionToken +
                 ", region='" + region + '\'' +
                 ", logLevel=" + logLevel +
                 ", keyStoreLocation='" + keyStoreLocation + '\'' +

--- a/src/main/java/org/opensearch/jdbc/config/ConnectionConfig.java
+++ b/src/main/java/org/opensearch/jdbc/config/ConnectionConfig.java
@@ -35,6 +35,9 @@ public class ConnectionConfig {
     private boolean requestCompression;
     private AuthenticationType authenticationType;
     private AWSCredentialsProvider awsCredentialsProvider;
+    private String awsAccessKey;
+    private String awsSecretKey;
+    private String awsSessionToken;
     private String region;
     private LogLevel logLevel;
 
@@ -68,6 +71,9 @@ public class ConnectionConfig {
         this.requestCompression = builder.getRequestCompressionProperty().getValue();
         this.authenticationType = builder.getAuthConnectionProperty().getValue();
         this.awsCredentialsProvider = builder.getAwsCredentialProvider().getValue();
+        this.awsAccessKey = builder.getAwsAccessKeyProperty().getValue();
+        this.awsSecretKey = builder.getAwsSecretKeyProperty().getValue();
+        this.awsSessionToken = builder.getAwsSessionTokenProperty().getValue();
         this.region = builder.getRegionConnectionProperty().getValue();
 
         this.keyStoreLocation = builder.getKeyStoreLocationConnectionProperty().getValue();
@@ -144,6 +150,18 @@ public class ConnectionConfig {
         return awsCredentialsProvider;
     }
 
+    public String getAwsAccessKey() {
+        return awsAccessKey;
+    }
+
+    public String getAwsSecretKey() {
+        return awsSecretKey;
+    }
+
+    public String getAwsSessionToken() {
+        return awsSessionToken;
+    }
+
     public String getRegion() {
         return region;
     }
@@ -205,6 +223,9 @@ public class ConnectionConfig {
                 ", requestCompression=" + requestCompression +
                 ", authenticationType=" + authenticationType +
                 ", awsCredentialsProvider=" + awsCredentialsProvider +
+            ", awsCredentialsProvider=" + awsCredentialsProvider +
+            ", awsCredentialsProvider=" + awsCredentialsProvider +
+            ", awsCredentialsProvider=" + awsCredentialsProvider +
                 ", region='" + region + '\'' +
                 ", logLevel=" + logLevel +
                 ", keyStoreLocation='" + keyStoreLocation + '\'' +
@@ -259,6 +280,9 @@ public class ConnectionConfig {
 
         private AwsCredentialsProviderProperty awsCredentialsProviderProperty
                 = new AwsCredentialsProviderProperty();
+        private AwsAccessKeyProperty awsAccessKeyProperty = new AwsAccessKeyProperty();
+        private AwsSecretKeyProperty awsSecretKeyProperty = new AwsSecretKeyProperty();
+        private AwsSessionTokenProperty awsSessionTokenProperty = new AwsSessionTokenProperty();
 
         private HostnameVerificationConnectionProperty hostnameVerificationConnectionProperty
                 = new HostnameVerificationConnectionProperty();
@@ -280,6 +304,9 @@ public class ConnectionConfig {
                 requestCompressionProperty,
                 authConnectionProperty,
                 awsCredentialsProviderProperty,
+                awsAccessKeyProperty,
+                awsSecretKeyProperty,
+                awsSessionTokenProperty,
                 regionConnectionProperty,
                 keyStoreLocationConnectionProperty,
                 keyStorePasswordConnectionProperty,
@@ -350,6 +377,18 @@ public class ConnectionConfig {
 
         public AwsCredentialsProviderProperty getAwsCredentialProvider() {
             return awsCredentialsProviderProperty;
+        }
+
+        public AwsAccessKeyProperty getAwsAccessKeyProperty() {
+            return awsAccessKeyProperty;
+        }
+
+        public AwsSecretKeyProperty getAwsSecretKeyProperty() {
+            return awsSecretKeyProperty;
+        }
+
+        public AwsSessionTokenProperty getAwsSessionTokenProperty() {
+            return awsSessionTokenProperty;
         }
 
         public RegionConnectionProperty getRegionConnectionProperty() {

--- a/src/main/java/org/opensearch/jdbc/transport/http/ApacheHttpTransport.java
+++ b/src/main/java/org/opensearch/jdbc/transport/http/ApacheHttpTransport.java
@@ -6,16 +6,13 @@
 
 package org.opensearch.jdbc.transport.http;
 
-import com.amazonaws.auth.AWS4Signer;
+import com.amazonaws.auth.*;
 import org.opensearch.jdbc.auth.AuthenticationType;
 import org.opensearch.jdbc.config.ConnectionConfig;
 import org.opensearch.jdbc.logging.Logger;
 import org.opensearch.jdbc.logging.LoggingSource;
 import org.opensearch.jdbc.transport.TransportException;
 import org.opensearch.jdbc.transport.http.auth.aws.AWSRequestSigningApacheInterceptor;
-import com.amazonaws.auth.AWS4UnsignedPayloadSigner;
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import org.apache.http.Header;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
@@ -114,8 +111,23 @@ public class ApacheHttpTransport implements HttpTransport, LoggingSource {
             signer.setServiceName("es");
             signer.setRegionName(connectionConfig.getRegion());
 
-            AWSCredentialsProvider provider = connectionConfig.getAwsCredentialsProvider() != null ?
-                    connectionConfig.getAwsCredentialsProvider() : new DefaultAWSCredentialsProviderChain();
+            AWSCredentialsProvider provider;
+            if (connectionConfig.getAwsCredentialsProvider() != null) {
+                provider = connectionConfig.getAwsCredentialsProvider();
+            } else if (connectionConfig.getAwsSessionToken() != null) {
+                AWSCredentials credentials = new BasicSessionCredentials(
+                    connectionConfig.getAwsAccessKey(),
+                    connectionConfig.getAwsSecretKey(),
+                    connectionConfig.getAwsSessionToken());
+                provider = new AWSStaticCredentialsProvider(credentials);
+            } else if (connectionConfig.getAwsAccessKey() != null) {
+                AWSCredentials credentials = new BasicAWSCredentials(
+                    connectionConfig.getAwsAccessKey(),
+                    connectionConfig.getAwsSecretKey());
+                provider = new AWSStaticCredentialsProvider(credentials);
+            } else {
+                provider = new DefaultAWSCredentialsProviderChain();
+            }
             httpClientBuilder.addInterceptorLast(
                     new AWSRequestSigningApacheInterceptor(
                             "es",


### PR DESCRIPTION
### Description
Adds AWS IAM driver properties.
This allows to connect to AWS instances without specifying env variables.
New properties:
- awsAccessKey
- awsSecretKey
- awsSessionToken

All are strings. Session token is optional and can be used for authentication through profiles, web identify, etc.
 
### Issues Resolved
https://github.com/opensearch-project/sql-jdbc/issues/22

There are not tests as it will require some AWS infrastructure.
However it was tested in DBeaver products.
 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).